### PR TITLE
Node modules update

### DIFF
--- a/lib/corpora.js
+++ b/lib/corpora.js
@@ -16,7 +16,7 @@ try {
   fs.statSync(path).isDirectory();
 } catch (e) {
   // fall back to old node_modules organization if necessary
-  path = __dirname.replace(/lib$/,'');
+  path = __dirname.replace(/lib$/,'') + 'node_modules/corpora/data/';
 }
 
 var _categories = function(directory) {

--- a/lib/corpora.js
+++ b/lib/corpora.js
@@ -9,11 +9,19 @@
 'use strict';
 
 var fs = require('fs');
-var path = __dirname.replace(/lib$/,'');
+var path = __dirname.replace(/corpora\-project\/lib$/,'') + 'corpora/data/';
+
+try {
+  // test to make sure corpora exists
+  fs.statSync(path).isDirectory()
+} catch (e) {
+  // fall back to old node_modules organization if necessary
+  path = __dirname.replace(/lib$/,'')
+}
 
 var _categories = function(directory) {
   directory = directory || '';
-  return fs.readdirSync(path + 'node_modules/corpora/data/' + directory)
+  return fs.readdirSync(path + directory)
     .filter(function(item) {
       // only include the item if it has no .json extension
       return !item.match('.json');
@@ -21,13 +29,13 @@ var _categories = function(directory) {
     .map(function(dirname) {
       return {
         name: dirname,
-        files: fs.readdirSync(path + 'node_modules/corpora/data/'+directory+'/'+dirname).map(function(filename) {
+        files: fs.readdirSync(path+directory+'/'+dirname).map(function(filename) {
           return {
             name: filename.replace('.json',''),
             // assume it's a directory if it's not a json file
             isDirectory: !filename.match('.json'),
             get: function() {
-              return JSON.parse(fs.readFileSync(path + 'node_modules/corpora/data/'+directory+'/'+dirname+'/'+filename));
+              return JSON.parse(fs.readFileSync(path+directory+'/'+dirname+'/'+filename));
             }
           };
         })

--- a/lib/corpora.js
+++ b/lib/corpora.js
@@ -13,10 +13,10 @@ var path = __dirname.replace(/corpora\-project\/lib$/,'') + 'corpora/data/';
 
 try {
   // test to make sure corpora exists
-  fs.statSync(path).isDirectory()
+  fs.statSync(path).isDirectory();
 } catch (e) {
   // fall back to old node_modules organization if necessary
-  path = __dirname.replace(/lib$/,'')
+  path = __dirname.replace(/lib$/,'');
 }
 
 var _categories = function(directory) {


### PR DESCRIPTION
npm has a newish behavior of flattening the `node_modules` folder instead of nesting dependencies, making `corpora-project`'s file paths incorrect when installed with newer versions of npm. This PR defaults to searching for the `corpora` dependency along the new directory structure, falling back to the old path if necessary.
